### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ docx2md NewDocument.docx
 ## Installation
 
 ```
-$ go get github.com/mattn/docx2md
+$ go install github.com/mattn/docx2md@latest
 ```
 
 ## Supported Styles


### PR DESCRIPTION
I updated the command since I got this error:

```
go get github.com/mattn/docx2md
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```